### PR TITLE
Use absolute paths when reading files.

### DIFF
--- a/src/leiningen/kibit.clj
+++ b/src/leiningen/kibit.clj
@@ -6,12 +6,11 @@
 (defn kibit
   "Suggest idiomatic replacements for patterns of code."
   [project]
-  (let [paths (or (:source-paths project) [(:source-path project)])
-        namespaces (apply concat (for [path paths]
-                                   (clj-ns/find-namespaces-in-dir (io/file path))))]
-    (doseq [ns-sym namespaces]
-      (try
-        (println "==" ns-sym "==")
-        (kibit/check-ns ns-sym)
-        (catch RuntimeException e (println ns-sym "not found.")))
-    (println "done."))))
+  (let [paths (or (:source-paths project) [(:source-path project)])]
+    (doseq [path paths]
+      (doseq [ns-sym (clj-ns/find-namespaces-in-dir (io/file path))]
+        (try
+          (println "==" ns-sym "==")
+          (kibit/check-ns ns-sym path)
+          (catch RuntimeException e (println ns-sym "not found.")))
+        (println "done.")))))


### PR DESCRIPTION
This should hopefully resolve https://github.com/jonase/kibit/issues/5

At the moment, the master branch for kibit seems to be broken. At least for me. Every form fails every rule when I run it. This change actually allows kibit to find the source files when a source-path besides 'src/' is used though.
