### PR TITLE
Concrete alternatives rather than just symbols or strings

### DIFF
--- a/src/jonase/kibit/control_structures.clj
+++ b/src/jonase/kibit/control_structures.clj
@@ -2,9 +2,9 @@
 
 (def rules
   '{(if ?x ?y nil) when
-    (if ?x nil ?y) when-not
+    (if ?x nil ?y) (when-not ?x ?y)
     (if ?x (do . ?y)) when
     (if (not ?x) ?y ?z) if-not
     (when (not ?x) . ?y) when-not
-    (if true ?x . ?y) "do or removing the if"})
+    (if true ?x . ?y) ?x})
 

--- a/src/jonase/kibit/core.clj
+++ b/src/jonase/kibit/core.clj
@@ -32,11 +32,12 @@
   ([expr]
    (check-form expr all-rules))
   ([expr rules]
-   (for [[rule alt] rules
-         :let [broken-rule (and (sequential? expr)
-                                (logic/unifier expr rule))]
+   (for [rule rules
+         :let [[_ alt :as unified] (logic/unifier rule [expr '?alt])
+               broken-rule (and (sequential? expr)
+                               unified)]
          :when (not (nil? broken-rule))]
-       (str "[Kibit] Consider " alt " instead of " expr))))
+     (str "[Kibit] Consider " (if (sequential? alt) (seq alt) alt) " instead of " expr))))
 
 (defn check
   "This is a presentation version of check-form,

--- a/test/kibit/test/control_structures.clj
+++ b/test/kibit/test/control_structures.clj
@@ -10,10 +10,13 @@
 ;; Please ensure that new rules generate fully expected results across all
 ;; rule sets.
 
-(deftest sloppy-if  
-  (let [exp-data '(if true (println "X"))
-        expected "[Kibit] Consider do or removing the if instead of (if true (println \"X\"))"
-        actual (doall (kibit/check-form exp-data))]
+(defn test-check-form [form alt]
+  (let [expected (str "[Kibit] Consider " alt " instead of " form)
+        actual (doall (kibit/check-form form))]
     (is (= (count actual) 1))
-    (is (= expected (first actual)))))
+    (is (= expected (first actual))))) 
 
+(deftest control-structures
+  (test-check-form '(if true (println "X")) '(println "X"))
+  (test-check-form '(if test nil else) '(when-not test else))
+  (test-check-form '(if test then nil) 'when))


### PR DESCRIPTION
logic/unifier can generate better alternatives such as: (when-not test else) instead of just when-not
