### PR TITLE
Filter simplified expressions in reporter, not in `simplify`

### DIFF
--- a/src/jonase/kibit/core.clj
+++ b/src/jonase/kibit/core.clj
@@ -51,9 +51,8 @@
                             :line (-> expr meta :line)}))))))
 
 ;; This walks across all the forms within an expression,
-;; checking each inner form. The outcome is a potential full alternative.
-;; We check to see if there is indeed a difference in the alternative,
-;; and if so, return a full simplify-map.
+;; checking each inner form and returning a full simplify-map.
+;; (Even if the forms are the same.)
 ;;
 ;; We build the simplify-map at the end because
 ;; Clojure 1.3 munges the metadata in transients (so also in clojure.walk).
@@ -64,10 +63,9 @@
     (let [line-num (-> expr meta :line)
           simp-partial #(simplify-one %1 rules)
           alt (walk/postwalk #(or (-> % simp-partial :alt) %) expr)]
-      (when-not (= expr alt)
-        {:expr expr
-         :alt alt
-         :line line-num}))))
+      {:expr expr
+       :alt alt
+       :line line-num})))
 
 ;; Reading source files
 ;; --------------------

--- a/src/jonase/kibit/reporters.clj
+++ b/src/jonase/kibit/reporters.clj
@@ -18,7 +18,7 @@
 
 (defn cli-reporter [check-map]
   (let [{:keys [line expr alt]} check-map]
-    (do 
+    (when (not= expr alt)
       (printf "[%s] Consider:\n" line)
       (pprint-code alt)
       (println "instead of:")


### PR DESCRIPTION
I'm putting together a tool that uses kibit for rewriting Clojure code into ClojureScript (see [cljsbuild issue here](https://github.com/emezeske/lein-cljsbuild/issues/49)). Most expressions stay the same and just need to get passed through to the reporter, so I've moved the filtering `(when-not (= alt expr) ...)` clause to the default cli reporter.
