### PR TITLE
Use check-file instead of check-reader.

### DIFF
--- a/src/kibit/check.clj
+++ b/src/kibit/check.clj
@@ -226,5 +226,5 @@
                                            :rules rules
                                            :guard guard
                                            :resolution resolution)]
-          (reporter simplify-map)))))
+          (reporter (assoc simplify-map :file source-file))))))
 

--- a/src/kibit/reporters.clj
+++ b/src/kibit/reporters.clj
@@ -28,9 +28,9 @@
 (defn cli-reporter
   "Print a check-map to `*out*`"
   [check-map]
-  (let [{:keys [line expr alt]} check-map]
-    (do 
-      (printf "[%s] Consider:\n" line)
+  (let [{:keys [file line expr alt]} check-map]
+    (do
+      (printf "At %s:%s:\nConsider using:\n" file line)
       (pprint-code alt)
       (println "instead of:")
       (pprint-code expr)

--- a/src/leiningen/kibit.clj
+++ b/src/leiningen/kibit.clj
@@ -11,15 +11,14 @@
   (let [paths (or (:source-paths project) [(:source-path project)])
         source-files (mapcat #(-> % io/file clj-ns/find-clojure-sources-in-dir) paths)]
     (doseq [source-file source-files]
-      (with-open [reader (io/reader source-file)]
-        (printf "== %s ==\n" (or (second (clj-ns/read-file-ns-decl source-file)) source-file))
-        (try
-          (->> (kibit/check-reader reader)
-               #_(filter #(contains? % :alt))
-               (map reporters/cli-reporter)
-               doall)
-          (catch Exception e
-            (println "Check failed -- skipping rest of file")
-            (println (.getMessage e))))))))
+      (printf "== %s ==\n" (or (second (clj-ns/read-file-ns-decl source-file)) source-file))
+      (try
+        (->> (kibit/check-file source-file)
+             #_(filter #(contains? % :alt))
+             (map reporters/cli-reporter)
+             doall)
+        (catch Exception e
+          (println "Check failed -- skipping rest of file")
+          (println (.getMessage e)))))))
 
 


### PR DESCRIPTION
Also, make check-file include :file metadata.  Show that including the line
number in a more conventional compiler output format, which can be easily
exploited by tools such as Emacs.

For example, the following implements kibit support for Emacs, i.e., M-x kibit
RET will run kibit in the current project and show its results in a
_compilation_ buffer, where all kibit suggestions are properly highlighted and
hyperlinked to the clojure source code files.

```
(require 'compile)

(add-to-list 'compilation-error-regexp-alist-alist
         '(kibit "At \\([^:]+\\):\\([[:digit:]]+\\):" 1 2 nil 0))

(add-to-list 'compilation-error-regexp-alist 'kibit)

(defun kibit ()
  "Run kibit on the current project.
Display the results in a hyperlinked *compilation* buffer."
  (interactive)
  (compile "lein kibit"))
```
