### PR TITLE
prefer (seq x) over (not (empty? x)

### DIFF
--- a/src/kibit/rules/collections.clj
+++ b/src/kibit/rules/collections.clj
@@ -6,6 +6,9 @@
   [(conj [] . ?x) (vector . ?x)]
   [(into [] ?coll) (vec ?coll)]
 
+  ;; empty?
+  [(not (empty? ?x)) (seq ?x)]
+
   ;; set
   [(into #{} ?coll) (set ?coll)])
 

--- a/test/kibit/test/collections.clj
+++ b/test/kibit/test/collections.clj
@@ -5,6 +5,7 @@
 (deftest collections-are
   (are [expected-alt-form test-form]
        (= expected-alt-form (:alt (kibit/check-expr test-form)))
+    '(seq a) '(not (empty? a))
     '(vector a) '(conj [] a)
     '(vector a b) '(conj [] a b)
     '(vec coll) '(into [] coll)


### PR DESCRIPTION
As recommended by the doc string for empty?
