### PR TITLE
Do forms are unneccesary in let forms.

### DIFF
--- a/src/kibit/rules/control_structures.clj
+++ b/src/kibit/rules/control_structures.clj
@@ -18,7 +18,7 @@
   ;; suggest `while` for bindingless loop-recur
   [(loop [] (when ?test . ?exprs (recur)))
    (while ?test . ?exprs)]
-  )
+  [(let ?binding (do . ?exprs)) (let ?binding . ?exprs)])
 
 (comment
   (when (not (pred? x y)) (f x y))

--- a/test/kibit/test/control_structures.clj
+++ b/test/kibit/test/control_structures.clj
@@ -16,4 +16,5 @@
     'single-expression '(do single-expression)
     '_ '(when-not true anything)
     '_ '(when false anything)
-    '(when-let [a test] expr) '(if-let [a test] expr nil)))
+    '(when-let [a test] expr) '(if-let [a test] expr nil)
+    '(let [a 1] (println a) a) '(let [a 1] (do (println a) a))))


### PR DESCRIPTION
do binding in let form is not neccessary as let provides an implicit do.

I do not know how common this is but I have discovered it in some of my earlier code.
