### PR TITLE
remove do in loop form

### DIFF
--- a/src/kibit/rules/control_structures.clj
+++ b/src/kibit/rules/control_structures.clj
@@ -18,7 +18,8 @@
   ;; suggest `while` for bindingless loop-recur
   [(loop [] (when ?test . ?exprs (recur)))
    (while ?test . ?exprs)]
-  [(let ?binding (do . ?exprs)) (let ?binding . ?exprs)])
+  [(let ?binding (do . ?exprs)) (let ?binding . ?exprs)]
+  [(loop ?binding (do . ?exprs)) (loop ?binding . ?exprs)])
 
 (comment
   (when (not (pred? x y)) (f x y))

--- a/test/kibit/test/control_structures.clj
+++ b/test/kibit/test/control_structures.clj
@@ -17,4 +17,7 @@
     '_ '(when-not true anything)
     '_ '(when false anything)
     '(when-let [a test] expr) '(if-let [a test] expr nil)
-    '(let [a 1] (println a) a) '(let [a 1] (do (println a) a))))
+    '(let [a 1] (println a) a) '(let [a 1] (do (println a) a))
+
+    '(loop [a 4] (println a) (if (zero? a) a (recur (dec a))))
+    '(loop [a 4] (do (println a) (if (zero? a) a (recur (dec a)))))))


### PR DESCRIPTION
loop provides implicit do form in construct.

Test for the new rule has space between it and the rest of the lines because it goes over two lines unlike the rest.
