### PR TITLE
Rule for redundant do inside a when

### DIFF
--- a/src/kibit/rules/control_structures.clj
+++ b/src/kibit/rules/control_structures.clj
@@ -14,6 +14,8 @@
   [(when-not true ?x) _]
   [(when false ?x) _]
   [(if-let ?binding ?expr nil) (when-let ?binding ?expr)]
+  [(when ?x (do . ?y)) (when ?x . ?y)]
+  [(when-not ?x (do . ?y)) (when-not ?x . ?y)]
 
   ;; suggest `while` for bindingless loop-recur
   [(loop [] (when ?test . ?exprs (recur)))
@@ -41,4 +43,4 @@
         (action d)
         (action f))
     nil))
-      
+

--- a/test/kibit/test/control_structures.clj
+++ b/test/kibit/test/control_structures.clj
@@ -18,6 +18,8 @@
     '_ '(when false anything)
     '(when-let [a test] expr) '(if-let [a test] expr nil)
     '(let [a 1] (println a) a) '(let [a 1] (do (println a) a))
+    '(when test (println a) then) '(when test (do (println a) then))
+    '(when-not test (println a) then) '(when-not test (do (println a) then))
 
     '(loop [a 4] (println a) (if (zero? a) a (recur (dec a))))
     '(loop [a 4] (do (println a) (if (zero? a) a (recur (dec a)))))))


### PR DESCRIPTION
``` clojure
(when something (do (println a) b))
```

simplifies to

``` clojure
(when something (println a) b)
```
