### PR TITLE
Added a rule for (apply str ..)

### DIFF
--- a/src/kibit/rules/misc.clj
+++ b/src/kibit/rules/misc.clj
@@ -16,6 +16,7 @@
   ;; clojure.string
   [(apply str (interpose ?x ?y)) (clojure.string/join ?x ?y)]
   [(apply str (reverse ?x)) (clojure.string/reverse ?x)]
+  [(apply str ?x) (clojure.string/join ?x)] 
 
   ;; mapcat
   [(apply concat (apply map ?x ?y)) (mapcat ?x ?y)]

--- a/test/kibit/test/misc.clj
+++ b/test/kibit/test/misc.clj
@@ -6,6 +6,7 @@
   (are [expected-alt-form test-form]
        (= expected-alt-form (:alt (kibit/check-expr test-form)))
     '(clojure.string/join x y) '(apply str (interpose x y))
+    '(clojure.string/join x) '(apply str x)
     '(clojure.string/reverse x) '(apply str (reverse x))
     '(mapcat x y) '(apply concat (apply map x y))
     '(mapcat x y) '(apply concat (map x y))


### PR DESCRIPTION
There were already rules for other `(apply str ..)` stuff such as reversal and interposing, but it should really always just `clojure.string/join`. This adds a rule that does that.

`clojure.string/join` is almost certainly more efficient than `(apply str ..)` since it has optimizations under the hood like using a `StringBuilder`.
