### PR TITLE
Fix invalid require in ns form

### DIFF
--- a/src/kibit/rules/util.clj
+++ b/src/kibit/rules/util.clj
@@ -1,5 +1,5 @@
 (ns kibit.rules.util
-  (require [clojure.core.logic :as logic]))
+  (:require [clojure.core.logic :as logic]))
 
 (defn compile-rule [rule]
   (let [[pat alt] (logic/prep rule)]


### PR DESCRIPTION
A very minor fix for the ns declaration in `kibit.rules.util`.

Also, the current `0.0.9-SNAPSHOT` jar contains AOT compiled classes for all deps. I think this maybe just be a mistake because of a dirty target/ directory on deploy, but I thought I'd mention it.

Cheers,

Ragnar
