### PR TITLE
expect source-paths, not project from the caller

### DIFF
--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -9,11 +9,11 @@
                  "The reporter used when rendering suggestions"
                  :default "text"]])
 
-(defn run [project & args]
+(defn run [source-paths & args]
   (let [[options file-args usage-text] (apply (partial cli args) cli-specs)
         source-files (if (empty? file-args)
                        (mapcat #(-> % io/file find-clojure-sources-in-dir)
-                               (or (:source-paths project) [(:source-path project)]))
+                               source-paths)
                        file-args)]
     (doseq [file source-files]
       (try (check-file file :reporter (name-to-reporter (:reporter options)


### PR DESCRIPTION
Hi Jonas,

As per a discussion with my colleague Jon Pither via IRC today, here is a pull request to make kibit/lein kibit more robust with non-standard roject files. For the record, the project file that was failing contained:

  :manifest {"Release-Version" ~#(str (:version %))
             "Git-Commit" ~git-commit}
