### PR TITLE
Add clojurescript, cljx, e.t.c. support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "Contact if any questions"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.logic "0.8.0-rc2"]
-                 [org.clojure/tools.namespace "0.2.1"]
                  [org.clojure/tools.cli "0.2.2"]]
-  :dev-dependencies [[lein-marginalia "0.7.0"]]
+  :profiles {:dev {:dependencies [[lein-marginalia "0.7.0"]]
+                   :resource-paths ["test/resources"]}}
   :warn-on-reflection false)

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -1,13 +1,34 @@
 (ns kibit.driver
-  (:require [clojure.tools.namespace :refer [find-clojure-sources-in-dir]]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [kibit.check :refer [check-file]]
             [kibit.reporters :refer :all]
-            [clojure.tools.cli :refer [cli]]))
+            [clojure.tools.cli :refer [cli]])
+  (:import [java.io File]))
 
 (def cli-specs [["-r" "--reporter"
                  "The reporter used when rendering suggestions"
                  :default "text"]])
+
+(defn ends-with?
+  "Returns true if the java.io.File ends in any of the strings in coll"
+  [file coll]
+  (some #(.endsWith (.getName file) %) coll))
+
+(defn clojure-file?
+  "Returns true if the java.io.File represents a Clojure source file.
+  Extensions taken from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml"
+  [file]
+  (and (.isFile file)
+       (ends-with? file [".clj" ".cl2" ".cljc" ".cljs" ".cljscm" ".cljx" ".hic" ".hl"])))
+
+(defn find-clojure-sources-in-dir
+  "Searches recursively under dir for Clojure source files.
+  Returns a sequence of File objects, in breadth-first sort order.
+  Taken from clojure.tools.namespace.find"
+  [^File dir]
+  ;; Use sort by absolute path to get breadth-first search.
+  (sort-by #(.getAbsolutePath ^File %)
+           (filter clojure-file? (file-seq dir))))
 
 (defn run [source-paths & args]
   (let [[options file-args usage-text] (apply (partial cli args) cli-specs)

--- a/test/kibit/test/driver.clj
+++ b/test/kibit/test/driver.clj
@@ -1,0 +1,17 @@
+(ns kibit.test.driver
+  (:require [kibit.driver :as driver]
+            [clojure.test :refer :all]
+            [clojure.java.io :as io]))
+
+(deftest clojure-file-are
+  (are [expected file] (= expected (driver/clojure-file? (io/file file)))
+       true "test/resources/first.clj"
+       true "test/resources/second.cljx"
+       true "test/resources/third.cljs"
+       false "test.resources/fourth.txt"))
+
+(deftest find-clojure-sources-are
+  (is (= [(io/file "test/resources/first.clj")
+          (io/file "test/resources/second.cljx")
+          (io/file "test/resources/third.cljs")]
+         (driver/find-clojure-sources-in-dir (io/file "test/resources")))))

--- a/test/resources/first.clj
+++ b/test/resources/first.clj
@@ -1,0 +1,1 @@
+Test file.

--- a/test/resources/fourth.txt
+++ b/test/resources/fourth.txt
@@ -1,0 +1,1 @@
+Shouldn't be scanned by kibit

--- a/test/resources/second.cljx
+++ b/test/resources/second.cljx
@@ -1,0 +1,1 @@
+Test file demonstrating cljx extension

--- a/test/resources/third.cljs
+++ b/test/resources/third.cljs
@@ -1,0 +1,1 @@
+Test file demonstrating clojurescript support.


### PR DESCRIPTION
This pr adds support for lots more alternate extensions for Clojure files. I've tested it on ClojureScript projects and it seems to run just fine.

Fixes #67 
