### PR TITLE
Return exit-code 1 when suggestions are found

### DIFF
--- a/src/kibit/check.clj
+++ b/src/kibit/check.clj
@@ -64,7 +64,7 @@ into the namespace."
                                  (read r false eof))
                           [ns? new-ns k] (when (sequential? form) form)
                           ns (if (and (symbol? new-ns)
-                                   (or (= ns? 'ns) (= ns? 'in-ns)))
+                                      (or (= ns? 'ns) (= ns? 'in-ns)))
                                (careful-refer (create-ns new-ns))
                                ns)]
                       (when-not (= form eof)
@@ -105,10 +105,10 @@ into the namespace."
   "Construct the canonical simplify-map
   given an expression and a simplified expression."
   [expr simplified-expr]
-  {:expr expr
-   :line (-> expr meta :line)
+  {:expr   expr
+   :line   (-> expr meta :line)
    :column (-> expr meta :column)
-   :alt simplified-expr})
+   :alt    simplified-expr})
 
 ;; ### Guarding the check
 
@@ -226,15 +226,16 @@ into the namespace."
   ""
   [source-file & kw-opts]
   (let [{:keys [rules guard resolution reporter init-ns]
-         :or {reporter reporters/cli-reporter}}
+         :or   {reporter reporters/cli-reporter}}
         (merge default-args
                (apply hash-map kw-opts))]
     (with-open [reader (io/reader source-file)]
       (with-bindings default-data-reader-binding
-        (doseq [simplify-map (check-reader reader
-                                           :rules rules
-                                           :guard guard
-                                           :resolution resolution
-                                           :init-ns init-ns)]
-          (reporter (assoc simplify-map :file source-file)))))))
-
+        (doall (map (fn [simplify-map]
+                      (do (reporter (assoc simplify-map :file source-file))
+                          simplify-map))
+                    (check-reader reader
+                                  :rules rules
+                                  :guard guard
+                                  :resolution resolution
+                                  :init-ns init-ns)))))))

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -36,9 +36,16 @@
                        (mapcat #(-> % io/file find-clojure-sources-in-dir)
                                source-paths)
                        file-args)]
-    (doseq [file source-files]
-      (try (check-file file :reporter (name-to-reporter (:reporter options)
-                                                        cli-reporter))
-           (catch Exception e
-             (println "Check failed -- skipping rest of file")
-             (println (.getMessage e)))))))
+    (mapcat (fn [file] (try (check-file file :reporter (name-to-reporter (:reporter options)
+                                                                         cli-reporter))
+                            (catch Exception e
+                              (println "Check failed -- skipping rest of file")
+                              (println (.getMessage e)))))
+            source-files)))
+
+(defn external-run
+  "Used by lein-kibit to count the results and exit with exit-code 1 if results are found"
+  [source-paths & args]
+  (if (zero? (count (apply run source-paths args)))
+    (System/exit 0)
+    (System/exit 1)))


### PR DESCRIPTION
Combined with jonase/lein-kibit#3, Kibit will exit with exit-code 1 when suggestions are found. This is most useful for CI tools.

Still to come before this is ready:
- [x] Check this was done idiomatically, need to think about the `for`
- [x] We might need to make a new `lein-kibit` function to call which then calls run, as `run` is calling System/exit at the moment which may break other usages of `run`.
- [x] Check behaviour on files passed directly
- [x] Check memory usage, as we are now holding onto all of the suggestion results

Fixes #88, and fixes jonase/lein-kibit#2
