### PR TITLE
Allow custom rules

### DIFF
--- a/src/kibit/check.clj
+++ b/src/kibit/check.clj
@@ -28,7 +28,7 @@
 ;; where necessary.
 ;;
 ;; For more information, see: [rules](#kibit.rules) namespace
-(def all-rules (map unifier/prep core-rules/all-rules))
+(def all-rules core-rules/all-rules)
 
 ;; Reading source files
 ;; --------------------
@@ -205,6 +205,7 @@ into the namespace."
         (merge default-args
                {:resolution :toplevel}
                (apply hash-map kw-opts))
+        rules (map unifier/prep rules)
         simplify-fn #((res->simplify resolution) % rules)]
     (check-aux expr simplify-fn guard)))
 
@@ -214,6 +215,7 @@ into the namespace."
   (let [{:keys [rules guard resolution init-ns]}
         (merge default-args
                (apply hash-map kw-opts))
+        rules (map unifier/prep rules)
         simplify-fn #((res->simplify resolution) % rules)]
     (keep #(check-aux % simplify-fn guard)
           ((res->read-seq resolution) reader init-ns))))

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -36,12 +36,12 @@
         source-files (mapcat #(-> % io/file find-clojure-sources-in-dir)
                              (if (empty? file-args) source-paths file-args))]
     (mapcat (fn [file] (try (check-file file
-                                       :reporter (name-to-reporter (:reporter options)
-                                                                   cli-reporter)
-                                       :rules (or rules all-rules))
-                           (catch Exception e
-                             (println "Check failed -- skipping rest of file")
-                             (println (.getMessage e)))))
+                                        :reporter (name-to-reporter (:reporter options)
+                                                                    cli-reporter)
+                                        :rules (or rules all-rules))
+                            (catch Exception e
+                              (println "Check failed -- skipping rest of file")
+                              (println (.getMessage e)))))
             source-files)))
 
 (defn external-run

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -1,5 +1,6 @@
 (ns kibit.driver
   (:require [clojure.java.io :as io]
+            [kibit.rules :refer [all-rules]]
             [kibit.check :refer [check-file]]
             [kibit.reporters :refer :all]
             [clojure.tools.cli :refer [cli]])
@@ -30,20 +31,22 @@
   (sort-by #(.getAbsolutePath ^File %)
            (filter clojure-file? (file-seq dir))))
 
-(defn run [source-paths & args]
+(defn run [source-paths rules & args]
   (let [[options file-args usage-text] (apply (partial cli args) cli-specs)
         source-files (mapcat #(-> % io/file find-clojure-sources-in-dir)
                              (if (empty? file-args) source-paths file-args))]
-    (mapcat (fn [file] (try (check-file file :reporter (name-to-reporter (:reporter options)
-                                                                         cli-reporter))
-                            (catch Exception e
-                              (println "Check failed -- skipping rest of file")
-                              (println (.getMessage e)))))
+    (mapcat (fn [file] (try (check-file file
+                                       :reporter (name-to-reporter (:reporter options)
+                                                                   cli-reporter)
+                                       :rules (or rules all-rules))
+                           (catch Exception e
+                             (println "Check failed -- skipping rest of file")
+                             (println (.getMessage e)))))
             source-files)))
 
 (defn external-run
   "Used by lein-kibit to count the results and exit with exit-code 1 if results are found"
-  [source-paths & args]
-  (if (zero? (count (apply run source-paths args)))
+  [source-paths rules & args]
+  (if (zero? (count (apply run source-paths rules args)))
     (System/exit 0)
     (System/exit 1)))


### PR DESCRIPTION
- Modify run and external-run to accept custom rules
- Create unifier/prep'ed rules inside check-expr and check-reader. This
  makes passing custom rules simpler
