### PR TITLE
Rule Set and File Exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,29 @@ instead of:
 ```clojure
   (if true (do (println "hi")))
 ```
+
+## Exclusions
+
+It's possible to exclude a particular rule from one file or from all
+files. It's also possible to exclude all rules for a given
+file. Simply modify `:exclusions` in the `:kibit` section of your
+profile.
+
+e.g.:
+```clojure
+(defproject myproject "0.1.0-SNAPSHOT"
+  ...
+  :profiles {:dev {:kibit {:excludes {"a.clj" #{:arithmetic :misc}
+                                      "b.clj" :all
+                                      :all #{:collections}}}}})
+```
+
+Currently supported rule sets for exclusion include
+`:control-structures`, `:arithmetic`, `:collections`, `:equality`, and
+`:misc`. See the current `rule-map` in
+[rules](https://github.com/jonase/kibit/blob/master/src/kibit/rules.clj)
+for reference.
+
 ...
 ----
 

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,11 @@
                  [org.clojure/core.logic "0.8.10"]
                  [org.clojure/tools.cli "0.3.1"]]
   :profiles {:dev {:dependencies [[lein-marginalia "0.8.0"]]
-                   :resource-paths ["test/resources"]}}
+                   :resource-paths ["test/resources"]
+                   :kibit {:excludes {"arithmetic.clj" :all
+                                      "collections.clj" :all
+                                      "control_structures.clj" :all
+                                      "equality.clj" :all
+                                      "misc.clj" :all}}}}
   :deploy-repositories [["releases" :clojars]]
   :warn-on-reflection false)

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -1,6 +1,6 @@
 (ns kibit.driver
   (:require [clojure.java.io :as io]
-            [kibit.rules :refer [all-rules]]
+            [kibit.rules :refer :all]
             [kibit.check :refer [check-file]]
             [kibit.reporters :refer :all]
             [clojure.tools.cli :refer [cli]])
@@ -31,23 +31,54 @@
   (sort-by #(.getAbsolutePath ^File %)
            (filter clojure-file? (file-seq dir))))
 
-(defn run [source-paths rules & args]
+(defn filtered-rules
+  [rules excludes file]
+  (let [file-entry (get excludes (.getName file))
+        file-excludes (if (= :all file-entry)
+                        #{:all}
+                        (clojure.set/union (get excludes :all)
+                                           file-entry))]
+    (seq (cond (:all file-excludes) nil
+               (= nil file-excludes) (or rules all-rules)
+               :else (or rules
+                         (rule-sets (clojure.set/difference (set (keys rule-map))
+                                                            file-excludes)))))))
+
+(defn run
+  "Runs analysis on all files under each of the paths specified in source-paths.
+  Accepts custom rules to be used in place of the default set of rules. Accepts
+  excludes, a map of rules to exclude per file.
+
+  excludes is specified with the following form:
+
+  {\"file-name.clj\" #{:all}
+  \"file-name2.cljx\" #{:rule1}
+  :all #{:rule1 :rule2}}
+
+  In excludes, :all may be used in place of either the file name or the rules in
+  order to exclude a rule-set for all files or all rule-sets for a file. When
+  using custom rules, :all may only be used to denote entire file exclusions
+  (i.e. {\"file\" #{:all}})"
+  [source-paths rules excludes & args]
   (let [[options file-args usage-text] (apply (partial cli args) cli-specs)
         source-files (mapcat #(-> % io/file find-clojure-sources-in-dir)
-                             (if (empty? file-args) source-paths file-args))]
-    (mapcat (fn [file] (try (check-file file
-                                        :reporter (name-to-reporter (:reporter options)
-                                                                    cli-reporter)
-                                        :rules (or rules all-rules))
-                            (catch Exception e
-                              (binding [*out* *err*]
-                                (println "Check failed -- skipping rest of file")
-                                (println (.getMessage e))))))
+                             (if (empty? file-args) source-paths file-args))
+        rule-filter-fn (partial filtered-rules rules excludes)]
+    (mapcat (fn [file] (try (if-let [file-rules (rule-filter-fn file)]
+                             (check-file file
+                                         :reporter (name-to-reporter (:reporter options)
+                                                                     cli-reporter)
+                                         :rules file-rules)
+                             (println "Skipping file: " (.getPath file)))
+                           (catch Exception e
+                             (binding [*out* *err*]
+                               (println "Check failed -- skipping rest of file")
+                               (println (.getMessage e))))))
             source-files)))
 
 (defn external-run
   "Used by lein-kibit to count the results and exit with exit-code 1 if results are found"
-  [source-paths rules & args]
-  (if (zero? (count (apply run source-paths rules args)))
+  [source-paths rules excludes & args]
+  (if (zero? (count (apply run source-paths rules excludes args)))
     (System/exit 0)
     (System/exit 1)))

--- a/src/kibit/driver.clj
+++ b/src/kibit/driver.clj
@@ -39,7 +39,7 @@
                         (clojure.set/union (get excludes :all)
                                            file-entry))]
     (seq (cond (:all file-excludes) nil
-               (= nil file-excludes) (or rules all-rules)
+               (nil? file-excludes) (or rules all-rules)
                :else (or rules
                          (rule-sets (clojure.set/difference (set (keys rule-map))
                                                             file-excludes)))))))

--- a/src/kibit/rules.clj
+++ b/src/kibit/rules.clj
@@ -37,3 +37,11 @@
 ;; TODO: Consider a refactor for this into a function
 ;; `(defn rules-for-ns [& namespaces])`
 (def all-rules (apply concat (vals rule-map)))
+
+(defn rule-sets
+  "Returns all rules for the given rule-sets. Currently supported rule-sets
+  include :control-structures, :arithmetic, :collections, :equality, and :misc"
+  [rule-sets]
+  (reduce (fn [rules rule-set]
+            (concat rules (rule-set rule-map)))
+          [] rule-sets))

--- a/test/kibit/test/driver.clj
+++ b/test/kibit/test/driver.clj
@@ -1,5 +1,7 @@
 (ns kibit.test.driver
   (:require [kibit.driver :as driver]
+            [kibit.rules :refer [all-rules rule-map]]
+            [kibit.rules.control-structures :as control]
             [clojure.test :refer :all]
             [clojure.java.io :as io]))
 

--- a/test/kibit/test/driver.clj
+++ b/test/kibit/test/driver.clj
@@ -15,3 +15,30 @@
           (io/file "test/resources/second.cljx")
           (io/file "test/resources/third.cljs")]
          (driver/find-clojure-sources-in-dir (io/file "test/resources")))))
+
+(deftest filtered-rules
+  (is (= all-rules (driver/filtered-rules nil
+                                          nil
+                                          (io/file "test/resources/first.clj"))))
+  (is (= nil (driver/filtered-rules :some-rules
+                                    {"first.clj" #{:all}}
+                                    (io/file "test/resources/first.clj"))))
+  (is (= nil (driver/filtered-rules nil
+                                    {"first.clj" #{:all}}
+                                    (io/file "test/resources/first.clj"))))
+  (is (= nil (driver/filtered-rules nil
+                                    {"first.clj" :all}
+                                    (io/file "test/resources/first.clj"))))
+  (is (= '(:some-rules) (driver/filtered-rules [:some-rules]
+                                               nil
+                                               (io/file "test/resources/first.clj"))))
+  (is (= '(:some-rules) (driver/filtered-rules [:some-rules]
+                                               {"first.clj" #{:some-rule-set}}
+                                               (io/file "test/resources/first.clj"))))
+  (is (= control/rules
+         (driver/filtered-rules nil
+                                {"first.clj" (-> rule-map
+                                                 keys
+                                                 set
+                                                 (disj :control-structures))}
+                                (io/file "test/resources/first.clj")))))


### PR DESCRIPTION
This is an enhancement that allows for the specification of exclusions when running kibit. With this, it will be possible to pass in exclusions in the form of a map, where keys are file names and values are sets of keywords representing default rule sets.

See the updated README.md for details.

A sister pull request will be made against lein-kibit in order to have it pull excludes from .project files.
