### PR TITLE
replace all the rules with a map that only contains the rule itself

### DIFF
--- a/kibit/src/kibit/rules/arithmetic.clj
+++ b/kibit/src/kibit/rules/arithmetic.clj
@@ -2,28 +2,28 @@
   (:use [kibit.rules.util :only [defrules]]))
 
 (defrules rules
-  [(+ ?x 1) (inc ?x)]
-  [(+ 1 ?x) (inc ?x)]
-  [(- ?x 1) (dec ?x)]
+  {:rule [(+ ?x 1) (inc ?x)]}
+  {:rule [(+ 1 ?x) (inc ?x)]}
+  {:rule [(- ?x 1) (dec ?x)]}
 
-  [(* ?x (* . ?xs)) (* ?x . ?xs)]
-  [(+ ?x (+ . ?xs)) (+ ?x . ?xs)]
+  {:rule [(* ?x (* . ?xs)) (* ?x . ?xs)]}
+  {:rule [(+ ?x (+ . ?xs)) (+ ?x . ?xs)]}
 
   ;;trivial identites
-  [(+ ?x 0) ?x]
-  [(- ?x 0) ?x]
-  [(* ?x 1) ?x]
-  [(/ ?x 1) ?x]
-  [(* ?x 0) 0]
+  {:rule [(+ ?x 0) ?x]}
+  {:rule [(- ?x 0) ?x]}
+  {:rule [(* ?x 1) ?x]}
+  {:rule [(/ ?x 1) ?x]}
+  {:rule [(* ?x 0) 0]}
 
   ;;Math/hypot
-  [(Math/sqrt (+ (Math/pow ?x 2) (Math/pow ?y 2))) (Math/hypot ?x ?y)]
+  {:rule [(Math/sqrt (+ (Math/pow ?x 2) (Math/pow ?y 2))) (Math/hypot ?x ?y)]}
 
   ;;Math/expm1
-  [(dec (Math/exp ?x)) (Math/expm1 ?x)]
+  {:rule [(dec (Math/exp ?x)) (Math/expm1 ?x)]}
 
   ;;ugly rounding tricks
-  [(long (+ ?x 0.5)) (Math/round ?x)]
+  {:rule [(long (+ ?x 0.5)) (Math/round ?x)]}
 )
 
 

--- a/kibit/src/kibit/rules/collections.clj
+++ b/kibit/src/kibit/rules/collections.clj
@@ -3,22 +3,22 @@
 
 (defrules rules
   ;;vector
-  [(conj [] . ?x) (vector . ?x)]
-  [(into [] ?coll) (vec ?coll)]
-  [(assoc ?coll ?key0 (assoc (?key0 ?coll) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]
-  [(assoc ?coll ?key0 (assoc (?coll ?key0) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]
-  [(assoc ?coll ?key0 (assoc (get ?coll ?key0) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]
-  [(assoc ?coll ?key (?fn (?key ?coll) . ?args)) (update-in ?coll [?key] ?fn . ?args)]
-  [(assoc ?coll ?key (?fn (?coll ?key) . ?args)) (update-in ?coll [?key] ?fn . ?args)]
-  [(assoc ?coll ?key (?fn (get ?coll ?key) . ?args)) (update-in ?coll [?key] ?fn . ?args)]
-  [(update-in ?coll ?keys assoc ?val) (assoc-in ?coll ?keys ?val)]
+  {:rule [(conj [] . ?x) (vector . ?x)]}
+  {:rule [(into [] ?coll) (vec ?coll)]}
+  {:rule [(assoc ?coll ?key0 (assoc (?key0 ?coll) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]}
+  {:rule [(assoc ?coll ?key0 (assoc (?coll ?key0) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]}
+  {:rule [(assoc ?coll ?key0 (assoc (get ?coll ?key0) ?key1 ?val)) (assoc-in ?coll [?key0 ?key1] ?val)]}
+  {:rule [(assoc ?coll ?key (?fn (?key ?coll) . ?args)) (update-in ?coll [?key] ?fn . ?args)]}
+  {:rule [(assoc ?coll ?key (?fn (?coll ?key) . ?args)) (update-in ?coll [?key] ?fn . ?args)]}
+  {:rule [(assoc ?coll ?key (?fn (get ?coll ?key) . ?args)) (update-in ?coll [?key] ?fn . ?args)]}
+  {:rule [(update-in ?coll ?keys assoc ?val) (assoc-in ?coll ?keys ?val)]}
 
   ;; empty?
-  [(not (empty? ?x)) (seq ?x)]
-  [(when-not (empty? ?x) . ?y) (when (seq ?x) . ?y)]
+  {:rule [(not (empty? ?x)) (seq ?x)]}
+  {:rule [(when-not (empty? ?x) . ?y) (when (seq ?x) . ?y)]}
 
   ;; set
-  [(into #{} ?coll) (set ?coll)]
+  {:rule [(into #{} ?coll) (set ?coll)]}
 
-  [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]
-  [(dorun (map ?fn ?coll)) (run! ?fn ?coll)])
+  {:rule (dorun (map ?fn ?coll)) (run! ?fn ?coll)}
+  {:rule [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]}))

--- a/kibit/src/kibit/rules/collections.clj
+++ b/kibit/src/kibit/rules/collections.clj
@@ -20,5 +20,5 @@
   ;; set
   {:rule [(into #{} ?coll) (set ?coll)]}
 
-  {:rule (dorun (map ?fn ?coll)) (run! ?fn ?coll)}
-  {:rule [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]}))
+  {:rule [(dorun (map ?fn ?coll)) (run! ?fn ?coll)]}
+  {:rule [(take ?n (repeatedly ?coll)) (repeatedly ?n ?coll)]})

--- a/kibit/src/kibit/rules/control_structures.clj
+++ b/kibit/src/kibit/rules/control_structures.clj
@@ -2,25 +2,25 @@
   (:use [kibit.rules.util :only [defrules]]))
 
 (defrules rules
-  [(if ?x ?y nil) (when ?x ?y)]
-  [(if ?x nil ?y) (when-not ?x ?y)]
-  [(if ?x (do . ?y)) (when ?x . ?y)]
-  [(if (not ?x) ?y ?z) (if-not ?x ?y ?z)]
-  [(if ?x ?x ?y) (or ?x ?y)]
-  [(when (not ?x) . ?y) (when-not ?x . ?y)]
-  [(do ?x) ?x]
-  [(if-let ?binding ?expr nil) (when-let ?binding ?expr)]
-  [(when ?x (do . ?y)) (when ?x . ?y)]
-  [(when-not ?x (do . ?y)) (when-not ?x . ?y)]
-  [(if-not ?x (do . ?y)) (when-not ?x . ?y)]
-  [(if-not (not ?x) ?y ?z) (if ?x ?y ?z)]
-  [(when-not (not ?x) . ?y) (when ?x . ?y)]
+  {:rule [(if ?x ?y nil) (when ?x ?y)]}
+  {:rule [(if ?x nil ?y) (when-not ?x ?y)]}
+  {:rule [(if ?x (do . ?y)) (when ?x . ?y)]}
+  {:rule [(if (not ?x) ?y ?z) (if-not ?x ?y ?z)]}
+  {:rule [(if ?x ?x ?y) (or ?x ?y)]}
+  {:rule [(when (not ?x) . ?y) (when-not ?x . ?y)]}
+  {:rule [(do ?x) ?x]}
+  {:rule [(if-let ?binding ?expr nil) (when-let ?binding ?expr)]}
+  {:rule [(when ?x (do . ?y)) (when ?x . ?y)]}
+  {:rule [(when-not ?x (do . ?y)) (when-not ?x . ?y)]}
+  {:rule [(if-not ?x (do . ?y)) (when-not ?x . ?y)]}
+  {:rule [(if-not (not ?x) ?y ?z) (if ?x ?y ?z)]}
+  {:rule [(when-not (not ?x) . ?y) (when ?x . ?y)]}
 
   ;; suggest `while` for bindingless loop-recur
-  [(loop [] (when ?test . ?exprs (recur)))
-   (while ?test . ?exprs)]
-  [(let ?binding (do . ?exprs)) (let ?binding . ?exprs)]
-  [(loop ?binding (do . ?exprs)) (loop ?binding . ?exprs)])
+  {:rule [(loop [] (when ?test . ?exprs (recur)))
+          (while ?test . ?exprs)]}
+  {:rule [(let ?binding (do . ?exprs)) (let ?binding . ?exprs)]}
+  {:rule [(loop ?binding (do . ?exprs)) (loop ?binding . ?exprs)]})
 
 (comment
   (when (not (pred? x y)) (f x y))

--- a/kibit/src/kibit/rules/equality.clj
+++ b/kibit/src/kibit/rules/equality.clj
@@ -3,25 +3,25 @@
 
 (defrules rules
   ;; not=
-  [(not (= . ?args)) (not= . ?args)]
+  {:rule [(not (= . ?args)) (not= . ?args)]}
 
   ;; zero?
-  [(= 0 ?x)  (zero? ?x)]
-  [(= ?x 0)  (zero? ?x)]
-  [(== 0 ?x) (zero? ?x)]
-  [(== ?x 0) (zero? ?x)]
+  {:rule [(= 0 ?x)  (zero? ?x)]}
+  {:rule [(= ?x 0)  (zero? ?x)]}
+  {:rule [(== 0 ?x) (zero? ?x)]}
+  {:rule [(== ?x 0) (zero? ?x)]}
 
-  [(< 0 ?x)  (pos? ?x)]
-  [(> ?x 0)  (pos? ?x)]
+  {:rule [(< 0 ?x)  (pos? ?x)]}
+  {:rule [(> ?x 0)  (pos? ?x)]}
 
-  [(< ?x 0) (neg? ?x)]
-  [(> 0 ?x) (neg? ?x)]
+  {:rule [(< ?x 0) (neg? ?x)]}
+  {:rule [(> 0 ?x) (neg? ?x)]}
 
   ;; true? false?
-  [(= true ?x) (true? ?x)]
-  [(= false ?x) (false? ?x)]
+  {:rule [(= true ?x) (true? ?x)]}
+  {:rule [(= false ?x) (false? ?x)]}
 
   ; nil?
-  [(= ?x nil) (nil? ?x)]
-  [(= nil ?x) (nil? ?x)])
+  {:rule [(= ?x nil) (nil? ?x)]}
+  {:rule [(= nil ?x) (nil? ?x)]})
 

--- a/kibit/src/kibit/rules/util.clj
+++ b/kibit/src/kibit/rules/util.clj
@@ -12,7 +12,7 @@
 
 (defmacro defrules [name & rules]
   `(let [rules# (for [rule# '~rules]
-                  (if (raw-rule? rule#)
-                    (eval rule#) ;; raw rule, no need to compile
-                    (compile-rule rule#)))]
+                  (if (raw-rule? (:rule rule#))
+                    (eval (:rule rule#)) ;; raw rule, no need to compile
+                    (compile-rule (:rule rule#))))]
      (def ~name (vec rules#))))


### PR DESCRIPTION
With this simple mechanical change (done simply with the power of Emacs query-replace-regexp and a few manual tweaks), all the tests are still passing, and it's a starting point to extend the rules to have a more rich structure, as discussed in 
https://github.com/jonase/kibit/issues/175
