### PR TITLE
Fix vary meta issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ script:
 - "lein test-all"
 jdk:
 - openjdk7
-- oraclejdk7
 - oraclejdk8

--- a/kibit/src/kibit/replace.clj
+++ b/kibit/src/kibit/replace.clj
@@ -71,11 +71,14 @@
                          (-> zipper rewrite.zip/node meta :row)))
       (recur (rewrite.zip/edit zipper
                                (fn -replace-zipper [sexpr]
-                                 (vary-meta (:alt check-map)
-                                            (fn -remove-loc [m]
-                                              (dissoc m
-                                                      :line
-                                                      :column)))))
+                                 (let [alt (:alt check-map)]
+                                   (if (meta alt)
+                                     (vary-meta alt
+                                                (fn -remove-loc [m]
+                                                  (dissoc m
+                                                          :line
+                                                          :column)))
+                                     alt))))
              reporter
              kw-opts)
       zipper)

--- a/kibit/test/kibit/test/replace.clj
+++ b/kibit/test/kibit/test/replace.clj
@@ -21,6 +21,9 @@
     '(inc a)
     '(+ 1 a)
 
+    '1
+    '(do 1)
+
     '(defn "Documentation" ^{:my-meta 1} [a]
        ;; a comment
        (inc a))
@@ -39,6 +42,9 @@
 
     "(inc a)"
     "(+ 1 a)"
+
+    "1"
+    "(do 1)"
 
     "(ns replace-file)
 


### PR DESCRIPTION
Hi, there's one particular case in which kibit seems to be broken. Replacing

```
(do 1)
```

with

```
1
```

Raises an exception related to the fact that you can't `vary-meta` a number. [Relevant line](https://github.com/jonase/kibit/blob/master/kibit/src/kibit/replace.clj?w=1#L74).

This fixes #213