### PR TITLE
Update dependencies to latest, remove unused lein-marginalia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,17 +1,16 @@
 (defproject jonase/kibit (clojure.string/trim-newline (slurp "resources/jonase/kibit/VERSION"))
   :description "There's a function for that!"
-  :url "https://github.com/jonase/kibit"
+  :url "https://github.com/clj-commons/kibit"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "Contact if any questions"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.logic "1.0.1"]
-                 [org.clojure/tools.cli "1.0.214"]
+                 [org.clojure/core.logic "1.1.0"]
+                 [org.clojure/tools.cli "1.1.230"]
                  [rewrite-clj "1.1.47"]
-                 [org.clojure/tools.reader "1.3.6"]]
-  :profiles {:dev {:dependencies [[lein-marginalia "0.9.0"]]
-                   :resource-paths ["test/resources"]}}
+                 [org.clojure/tools.reader "1.4.2"]]
+  :profiles {:dev {:resource-paths ["test/resources"]}}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :aliases {"test-all" ["do"


### PR DESCRIPTION
`lein-marginalia` has been unused since added. (Can't even be used until it's moved to `:plugins`.)

I read each of the dependency's change logs and perused the code changes. Nothing stood out but I prefer to stay up to date even when there are minimal needed changes.