### PR TITLE
Update version specified in README to reflect latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For other Clojure linters, see [clj-kondo](https://github.com/borkdude/clj-kondo
 
 ## Usage
 
-Add `[lein-kibit "0.1.9"]` to your `:plugins` vector in your `:user` profile. Then you can run
+Add `[lein-kibit "0.1.11"]` to your `:plugins` vector in your `:user` profile. Then you can run
 
     $ lein kibit
 


### PR DESCRIPTION
Version 0.1.9 is specified in the README but is no longer available, so updating the README to the latest release of 0.1.11 will help avoid confusion for new users (like me)